### PR TITLE
refactor(reselect): Removing depricated compile transclude function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+bower_components
 node_modules
+/.idea
+.DS_Store

--- a/src/reselect.directive.js
+++ b/src/reselect.directive.js
@@ -16,31 +16,28 @@ Reselect.value('reselectDefaultOptions', {
 			ngModel         : '=',
 			reselectOptions : '='
 		},
-		compile: function($element, $attrs, transcludeFn){
+		link: function($scope, $element, $attrs, ctrls, transcludeFn){
 
-			return function($scope, $element, $attrs, ctrls){
-				var $Reselect = ctrls[0];
-				var $transcludeElems = null;
+			var $Reselect = ctrls[0];
+			var $transcludeElems = null;
 
-				transcludeFn($scope, function(clone){
-					$transcludeElems = clone;
-					$element.append(clone);
-				}).detach();
+			transcludeFn($scope, function(clone){
+				$transcludeElems = clone;
+				$element.append(clone);
+			}).detach();
 
-				$transcludeElems = angular.element('<div>').append($transcludeElems);
+			$transcludeElems = angular.element('<div>').append($transcludeElems);
 
-				var $choice = $transcludeElems[0].querySelectorAll('.reselect-choices, [reselect-choices]');
-				var $selection = $transcludeElems[0].querySelectorAll('.reselect-selection, [reselect-selection]');
-					$selection = $selection.length ? $selection : $Reselect.options.selectionTemplate.clone();
+			var $choice = $transcludeElems[0].querySelectorAll('.reselect-choices, [reselect-choices]');
+			var $selection = $transcludeElems[0].querySelectorAll('.reselect-selection, [reselect-selection]');
+				$selection = $selection.length ? $selection : $Reselect.options.selectionTemplate.clone();
 
-				angular.element($element[0].querySelectorAll('.reselect-dropdown')).append($choice);
-				angular.element($element[0].querySelectorAll('.reselect-rendered-selection')).append($selection);
+			angular.element($element[0].querySelectorAll('.reselect-dropdown')).append($choice);
+			angular.element($element[0].querySelectorAll('.reselect-rendered-selection')).append($selection);
 
-				$Reselect.transcludeCtrls.$ReselectChoice = angular.element($choice).controller('reselectChoices');
+			$Reselect.transcludeCtrls.$ReselectChoice = angular.element($choice).controller('reselectChoices');
 
-				$compile($selection)($Reselect.selection_scope);
-			};
-
+			$compile($selection)($Reselect.selection_scope);
 		},
 		controllerAs: '$reselect',
 		controller: ['$scope', '$element', 'reselectDefaultOptions', '$timeout', function($scope, $element, reselectDefaultOptions, $timeout){


### PR DESCRIPTION
Updating compile function to link function in reselect directive. The compile transclude function is depricated, using the link transclude function now as noted in the [angular docs](https://docs.angularjs.org/api/ng/service/$compile).
